### PR TITLE
String values that consist of only the character '0' are no longer considered empty

### DIFF
--- a/Base.php
+++ b/Base.php
@@ -712,7 +712,7 @@ class phpDataMapper_Base
 	 */
 	public function isEmpty($value)
 	{
-		return (empty($value) && 0 !== $value);
+		return (empty($value) && 0 !== $value && '0' !== $value);
 	}
 	
 	


### PR DESCRIPTION
When saving objects, if I had a string that consisted of only the character '0' it would be entered into the database as NULL. This was undesired behavior as that string was considered a valid input in regards to our application.

The isEmpty function in Base,php uses the PHP function empty() to determine if a field is empty. PHP's empty() considers '0' to be an empty value. In this instance the isEmpty function was over stepping its bounds and changing an input.
